### PR TITLE
refactor: migrate proxmox vms into reusable module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .terraform/
 terraform.tfvars
 .env
+*.tfstate*
+tfplan
+crash.log
+.env.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ There is no dedicated test framework in this repository. Use:
 
 ## Agent Workflow Requirements
 - At the start of each new task, ask whether to create a new branch and suggest a Conventional Commits-style branch name (for example, `refactor/name-keyed-for-each`).
+- Before proposing changes, confirm they are the safest senior-level approach given the repo constraints (especially no VM recreation and locked VMIDs/IPs).
+- Review the actual file changes locally before asking the user to run any commands.
 - After a task or phase is approved, make a commit using Conventional Commits style.
 - When requested to open a pull request, use `gh pr create` and target the agreed base branch.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is a single Terraform configuration for Proxmox. The root directory holds all HCL sources:
+- Core configuration: `main.tf`, `provider.tf`, `variables.tf`, `locals.tf`.
+- Resource groups are split by role in `r_control_planes.tf`, `r_worker_nodes.tf`, `r_nfs_node.tf`, and `r_hl_vm_node.tf`.
+- Inputs live in `terraform.tfvars` (local, uncommitted) with a template at `terraform.tfvars.sample`. The provider is pinned in `.terraform.lock.hcl`.
+
+## Build, Test, and Development Commands
+- `terraform init` initializes the working directory and configures the backend.
+- `terraform fmt` formats all Terraform files to the standard style.
+- `terraform validate` performs a static validation of the configuration.
+- `terraform plan -out=tfplan` creates an execution plan and writes it to `tfplan`.
+- `terraform apply tfplan` applies the previously generated plan.
+
+## Coding Style & Naming Conventions
+- Use `terraform fmt` before committing; indentation is handled automatically.
+- Prefer snake_case for variable names (e.g., `cloudinit_sshkey`) and keep resource names consistent with existing patterns.
+- Keep resource definitions grouped by role in the `r_*.tf` files to match the current layout.
+
+## Testing Guidelines
+There is no dedicated test framework in this repository. Use:
+- `terraform validate` for configuration checks.
+- `terraform plan` to review all changes before apply.
+
+## Commit & Pull Request Guidelines
+- Commit messages follow a Conventional Commits-style prefix, e.g., `chore: update resources`.
+- Pull requests should include a clear description of changes and a `terraform plan` summary or output (redact secrets).
+
+## Agent Workflow Requirements
+- At the start of each new task, ask whether to create a new branch and suggest a Conventional Commits-style branch name (for example, `refactor/name-keyed-for-each`).
+- After a task or phase is approved, make a commit using Conventional Commits style.
+- When requested to open a pull request, use `gh pr create` and target the agreed base branch.
+
+## Security & Configuration Tips
+- Do not commit secrets. Keep credentials and tokens in `terraform.tfvars` or your local environment.
+- Use `terraform.tfvars.sample` as the base for new environments.

--- a/docs/refactor-plan.md
+++ b/docs/refactor-plan.md
@@ -1,5 +1,7 @@
 # Terraform Proxmox Refactor Plan (Single Environment)
 
+Date completed: 2026-01-25
+
 ## Goals and Guardrails
 - Keep the current workflow: run `terraform plan` / `terraform apply` from repo root.
 - Reduce duplication across `r_*.tf` files.

--- a/modules/proxmox-vm/main.tf
+++ b/modules/proxmox-vm/main.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "3.0.2-rc07"
+    }
+  }
+}
+
+resource "proxmox_vm_qemu" "this" {
+  name        = var.name
+  description = var.name
+  target_node = var.target_node
+
+  clone = var.clone
+  agent = var.agent
+
+  os_type = var.os_type
+
+  cpu {
+    cores   = var.cores
+    vcores  = var.vcores
+    sockets = var.sockets
+    type    = var.cpu_type
+  }
+
+  memory             = var.memory
+  balloon            = var.balloon
+  scsihw             = var.scsihw
+  bootdisk           = var.bootdisk
+  start_at_node_boot = var.start_at_node_boot
+  tags               = var.tags
+
+  startup_shutdown {
+    order         = var.startup_order
+    startup_delay = var.startup_delay
+  }
+
+  lifecycle {
+    ignore_changes = [bootdisk]
+  }
+
+  disks {
+    ide {
+      ide2 {
+        cloudinit {
+          storage = var.cloudinit_storage
+        }
+      }
+    }
+    scsi {
+      scsi0 {
+        disk {
+          size    = var.scsi0_size
+          cache   = var.scsi0_cache
+          storage = var.scsi0_storage
+        }
+      }
+
+      dynamic "scsi1" {
+        for_each = var.scsi1_size != null && var.scsi1_storage != null ? [1] : []
+        content {
+          disk {
+            size    = var.scsi1_size
+            cache   = var.scsi0_cache
+            storage = var.scsi1_storage
+          }
+        }
+      }
+    }
+  }
+
+  network {
+    id     = 0
+    model  = var.network_model
+    bridge = var.network_bridge
+  }
+
+  boot = var.boot
+
+  ciuser     = var.ciuser
+  cipassword = var.cipassword
+  ciupgrade  = var.ciupgrade
+  sshkeys    = var.sshkeys
+
+  searchdomain = var.searchdomain
+  nameserver   = var.nameserver
+
+  ipconfig0 = var.ipconfig0
+  vmid      = var.vmid
+}

--- a/modules/proxmox-vm/outputs.tf
+++ b/modules/proxmox-vm/outputs.tf
@@ -1,0 +1,7 @@
+output "vm_id" {
+  value = proxmox_vm_qemu.this.vmid
+}
+
+output "name" {
+  value = proxmox_vm_qemu.this.name
+}

--- a/modules/proxmox-vm/variables.tf
+++ b/modules/proxmox-vm/variables.tf
@@ -1,0 +1,159 @@
+variable "name" {
+  type = string
+}
+
+variable "target_node" {
+  type = string
+}
+
+variable "clone" {
+  type    = string
+  default = null
+}
+
+variable "agent" {
+  type    = number
+  default = 1
+}
+
+variable "os_type" {
+  type    = string
+  default = "cloud-init"
+}
+
+variable "cores" {
+  type = number
+}
+
+variable "memory" {
+  type = number
+}
+
+variable "balloon" {
+  type    = number
+  default = null
+}
+
+variable "cpu_type" {
+  type    = string
+  default = "host"
+}
+
+variable "sockets" {
+  type    = number
+  default = 1
+}
+
+variable "vcores" {
+  type    = number
+  default = 0
+}
+
+variable "scsihw" {
+  type    = string
+  default = "virtio-scsi-pci"
+}
+
+variable "bootdisk" {
+  type    = string
+  default = "scsi0"
+}
+
+variable "start_at_node_boot" {
+  type    = bool
+  default = true
+}
+
+variable "tags" {
+  type    = string
+  default = null
+}
+
+variable "startup_order" {
+  type = number
+}
+
+variable "startup_delay" {
+  type    = number
+  default = 10
+}
+
+variable "cloudinit_storage" {
+  type    = string
+  default = "local-lvm"
+}
+
+variable "scsi0_size" {
+  type = number
+}
+
+variable "scsi0_storage" {
+  type = string
+}
+
+variable "scsi0_cache" {
+  type    = string
+  default = "none"
+}
+
+variable "scsi1_size" {
+  type    = number
+  default = null
+}
+
+variable "scsi1_storage" {
+  type    = string
+  default = null
+}
+
+variable "network_bridge" {
+  type    = string
+  default = "vmbr0"
+}
+
+variable "network_model" {
+  type    = string
+  default = "virtio"
+}
+
+variable "boot" {
+  type    = string
+  default = "order=scsi0"
+}
+
+variable "ciuser" {
+  type = string
+}
+
+variable "cipassword" {
+  type      = string
+  sensitive = true
+}
+
+variable "ciupgrade" {
+  type    = bool
+  default = false
+}
+
+variable "sshkeys" {
+  type      = string
+  sensitive = true
+}
+
+variable "searchdomain" {
+  type    = string
+  default = null
+}
+
+variable "nameserver" {
+  type    = string
+  default = null
+}
+
+variable "ipconfig0" {
+  type = string
+}
+
+variable "vmid" {
+  type = any
+}

--- a/moved.tf
+++ b/moved.tf
@@ -57,3 +57,63 @@ moved {
   from = proxmox_vm_qemu.hl_vm_nodes["4"]
   to   = proxmox_vm_qemu.hl_vm_nodes["harness-delegate-1"]
 }
+
+moved {
+  from = proxmox_vm_qemu.control_planes["k8s-ctrl-0"]
+  to   = module.control_planes["k8s-ctrl-0"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["k8s-worker-0"]
+  to   = module.worker_nodes["k8s-worker-0"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["k8s-worker-1"]
+  to   = module.worker_nodes["k8s-worker-1"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["k8s-worker-2"]
+  to   = module.worker_nodes["k8s-worker-2"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["k8s-worker-3"]
+  to   = module.worker_nodes["k8s-worker-3"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["k8s-worker-sm-0"]
+  to   = module.worker_nodes["k8s-worker-sm-0"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.nfs_nodes["k8s-nfs-storage"]
+  to   = module.nfs_nodes["k8s-nfs-storage"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["tailscale"]
+  to   = module.hl_vm_nodes["tailscale"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["docker-net"]
+  to   = module.hl_vm_nodes["docker-net"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["minio"]
+  to   = module.hl_vm_nodes["minio"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["docker-priv"]
+  to   = module.hl_vm_nodes["docker-priv"].proxmox_vm_qemu.this
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["harness-delegate-1"]
+  to   = module.hl_vm_nodes["harness-delegate-1"].proxmox_vm_qemu.this
+}

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,59 @@
+moved {
+  from = proxmox_vm_qemu.control_planes["0"]
+  to   = proxmox_vm_qemu.control_planes["k8s-ctrl-0"]
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["0"]
+  to   = proxmox_vm_qemu.worker_nodes["k8s-worker-0"]
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["1"]
+  to   = proxmox_vm_qemu.worker_nodes["k8s-worker-1"]
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["2"]
+  to   = proxmox_vm_qemu.worker_nodes["k8s-worker-2"]
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["3"]
+  to   = proxmox_vm_qemu.worker_nodes["k8s-worker-3"]
+}
+
+moved {
+  from = proxmox_vm_qemu.worker_nodes["4"]
+  to   = proxmox_vm_qemu.worker_nodes["k8s-worker-sm-0"]
+}
+
+moved {
+  from = proxmox_vm_qemu.nfs_nodes["0"]
+  to   = proxmox_vm_qemu.nfs_nodes["k8s-nfs-storage"]
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["0"]
+  to   = proxmox_vm_qemu.hl_vm_nodes["tailscale"]
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["1"]
+  to   = proxmox_vm_qemu.hl_vm_nodes["docker-net"]
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["2"]
+  to   = proxmox_vm_qemu.hl_vm_nodes["minio"]
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["3"]
+  to   = proxmox_vm_qemu.hl_vm_nodes["docker-priv"]
+}
+
+moved {
+  from = proxmox_vm_qemu.hl_vm_nodes["4"]
+  to   = proxmox_vm_qemu.hl_vm_nodes["harness-delegate-1"]
+}

--- a/r_control_planes.tf
+++ b/r_control_planes.tf
@@ -1,5 +1,5 @@
 resource "proxmox_vm_qemu" "control_planes" {
-  for_each    = { for idx, cp in var.control_planes : idx => cp }
+  for_each    = { for idx, cp in var.control_planes : cp.name => merge(cp, { _idx = idx }) }
   name        = each.value.name
   description = each.value.name
 
@@ -83,6 +83,6 @@ resource "proxmox_vm_qemu" "control_planes" {
 
   # Setup ip address using cloud-init
   # Keep in mind to use CIDR notation for the ip
-  ipconfig0 = "ip=${var.static_ip_prefix}.${local.control_plane_start_id_suffix + tonumber(each.key)}/${var.network_prefix},gw=${var.network_gateway}"
-  vmid      = "3${local.control_plane_start_id_suffix + tonumber(each.key)}"
+  ipconfig0 = "ip=${var.static_ip_prefix}.${local.control_plane_start_id_suffix + each.value._idx}/${var.network_prefix},gw=${var.network_gateway}"
+  vmid      = "3${local.control_plane_start_id_suffix + each.value._idx}"
 }

--- a/r_control_planes.tf
+++ b/r_control_planes.tf
@@ -1,88 +1,27 @@
-resource "proxmox_vm_qemu" "control_planes" {
-  for_each    = { for idx, cp in var.control_planes : cp.name => merge(cp, { _idx = idx }) }
+module "control_planes" {
+  source   = "./modules/proxmox-vm"
+  for_each = { for idx, cp in var.control_planes : cp.name => merge(cp, { _idx = idx }) }
+
   name        = each.value.name
-  description = each.value.name
-
-  # Node name has to be the same name as within the cluster
-  # this might not include the FQDN
   target_node = each.value.node
+  clone       = var.template
 
-  # The destination resource pool for the new VM
-  # pool = "pool0"
+  cores  = var.vm_resources["control_plane"].cores
+  memory = var.vm_resources["control_plane"].memory
 
-  # The template name to clone this vm from
-  clone = var.template
+  scsi0_size    = var.vm_resources["control_plane"].disk
+  scsi0_storage = "local-lvm"
 
-  # Activate QEMU agent for this VM
-  agent = 1
+  tags          = var.tags["control_planes"]
+  startup_order = 7
 
-  os_type = "cloud-init"
-
-  cpu {
-    cores   = var.vm_resources["control_plane"].cores
-    vcores  = 0
-    sockets = 1
-    type    = "host"
-  }
-
-  memory             = var.vm_resources["control_plane"].memory
-  scsihw             = "virtio-scsi-pci"
-  bootdisk           = "scsi0"
-  start_at_node_boot = true
-  tags               = var.tags["control_planes"]
-
-  startup_shutdown {
-    order         = 7
-    startup_delay = 10
-  }
-
-  lifecycle {
-    ignore_changes = [bootdisk]
-  }
-  # Setup the disk
-  disks {
-    ide {
-      ide2 {
-        cloudinit {
-          storage = "local-lvm"
-        }
-      }
-    }
-    scsi {
-      scsi0 {
-        disk {
-          size    = var.vm_resources["control_plane"].disk
-          cache   = "none"
-          storage = "local-lvm"
-          # discard    = true
-          # backup     = true
-          # asyncio    = "io_uring"
-        }
-      }
-    }
-  }
-
-  # Setup Network interface and assign vlan tag
-  network {
-    id     = 0
-    model  = "virtio"
-    bridge = "vmbr0"
-  }
-
-  boot = "order=scsi0"
-
-  # Cloud init Settings
   ciuser     = var.cloudinit_user
   cipassword = var.cloudinit_password
-  ciupgrade  = false
   sshkeys    = var.cloudinit_sshkey
 
-  # DNS Settings
   searchdomain = var.dns_domain
   nameserver   = var.dns_nameserver
 
-  # Setup ip address using cloud-init
-  # Keep in mind to use CIDR notation for the ip
   ipconfig0 = "ip=${var.static_ip_prefix}.${local.control_plane_start_id_suffix + each.value._idx}/${var.network_prefix},gw=${var.network_gateway}"
   vmid      = "3${local.control_plane_start_id_suffix + each.value._idx}"
 }

--- a/r_hl_vm_node.tf
+++ b/r_hl_vm_node.tf
@@ -1,102 +1,28 @@
-resource "proxmox_vm_qemu" "hl_vm_nodes" {
-  for_each    = { for idx, cp in var.hl_vm_nodes : cp.name => merge(cp, { _idx = idx }) }
+module "hl_vm_nodes" {
+  source   = "./modules/proxmox-vm"
+  for_each = { for idx, cp in var.hl_vm_nodes : cp.name => merge(cp, { _idx = idx }) }
+
   name        = each.value.name
-  description = each.value.name
-
-  # Node name has to be the same name as within the cluster
-  # this might not include the FQDN
   target_node = each.value.node
+  clone       = try(each.value.clone, false) ? var.template : null
 
-  # The destination resource pool for the new VM
-  # pool = "pool0"
+  cores   = var.vm_resources["vm_${each.value.type}"].cores
+  memory  = var.vm_resources["vm_${each.value.type}"].memory
+  balloon = var.vm_resources["vm_${each.value.type}"].balloon
 
-  # The template name to clone this vm from
-  clone = each.value.clone ? var.template : null
+  scsi0_size    = var.vm_resources["vm_${each.value.type}"].disk
+  scsi0_storage = each.value.storage
 
-  # Activate QEMU agent for this VM
-  agent = 1
+  scsi1_size    = each.value.extra_disk != null ? var.vm_resources["storage_${each.value.extra_disk}"].size : null
+  scsi1_storage = each.value.extra_disk != null ? var.vm_resources["storage_${each.value.extra_disk}"].source : null
 
-  os_type = "cloud-init"
+  tags          = each.value.tags
+  startup_order = 6
 
-  cpu {
-    cores   = var.vm_resources["vm_${each.value.type}"].cores
-    vcores  = 0
-    sockets = 1
-    type    = "host"
-  }
-
-  memory             = var.vm_resources["vm_${each.value.type}"].memory
-  balloon            = var.vm_resources["vm_${each.value.type}"].balloon
-  scsihw             = "virtio-scsi-pci"
-  bootdisk           = "scsi0"
-  start_at_node_boot = true
-  tags               = each.value.tags
-
-  startup_shutdown {
-    order         = 6
-    startup_delay = 10
-  }
-
-  lifecycle {
-    ignore_changes = [bootdisk]
-  }
-
-  # Setup the disk
-  disks {
-    ide {
-      ide2 {
-        cloudinit {
-          storage = "local-lvm"
-        }
-      }
-    }
-    scsi {
-      scsi0 {
-        disk {
-          size    = var.vm_resources["vm_${each.value.type}"].disk
-          cache   = "none"
-          storage = each.value.storage
-          # discard    = true
-          # backup     = true
-          # asyncio    = "io_uring"
-        }
-      }
-
-      dynamic "scsi1" {
-        for_each = each.value.extra_disk != null ? [1] : []
-        content {
-          disk {
-            size    = var.vm_resources["storage_${each.value.extra_disk}"].size
-            cache   = "none"
-            storage = var.vm_resources["storage_${each.value.extra_disk}"].source
-          }
-        }
-      }
-    }
-  }
-
-
-  # Setup Network interface and assign vlan tag
-  network {
-    id     = 0
-    model  = "virtio"
-    bridge = "vmbr0"
-  }
-
-  boot = "order=scsi0"
-
-  # Cloud init Settings
   ciuser     = var.cloudinit_user
   cipassword = var.cloudinit_password
-  ciupgrade  = false
   sshkeys    = var.cloudinit_sshkey
 
-  # DNS Settings
-  # searchdomain = var.dns_domain
-  # nameserver   = var.dns_nameserver
-
-  # Setup ip address using cloud-init
-  # Keep in mind to use CIDR notation for the ip
   vmid = (each.value.vm_id_suffix != null ?
     3000 + each.value.vm_id_suffix :
     3000 + local.hl_vm_node_start_id_suffix + each.value._idx

--- a/r_hl_vm_node.tf
+++ b/r_hl_vm_node.tf
@@ -1,5 +1,5 @@
 resource "proxmox_vm_qemu" "hl_vm_nodes" {
-  for_each    = { for idx, cp in var.hl_vm_nodes : idx => cp }
+  for_each    = { for idx, cp in var.hl_vm_nodes : cp.name => merge(cp, { _idx = idx }) }
   name        = each.value.name
   description = each.value.name
 
@@ -99,10 +99,10 @@ resource "proxmox_vm_qemu" "hl_vm_nodes" {
   # Keep in mind to use CIDR notation for the ip
   vmid = (each.value.vm_id_suffix != null ?
     3000 + each.value.vm_id_suffix :
-    3000 + local.hl_vm_node_start_id_suffix + tonumber(each.key)
+    3000 + local.hl_vm_node_start_id_suffix + each.value._idx
   )
   ipconfig0 = "ip=${var.static_ip_prefix}.${
     each.value.vm_id_suffix != null ? each.value.vm_id_suffix :
-    local.hl_vm_node_start_id_suffix + tonumber(each.key)
+    local.hl_vm_node_start_id_suffix + each.value._idx
   }/${var.network_prefix},gw=${var.network_gateway}"
 }

--- a/r_nfs_node.tf
+++ b/r_nfs_node.tf
@@ -1,5 +1,5 @@
 resource "proxmox_vm_qemu" "nfs_nodes" {
-  for_each    = { for idx, cp in var.nfs_nodes : idx => cp }
+  for_each    = { for idx, cp in var.nfs_nodes : cp.name => merge(cp, { _idx = idx }) }
   name        = each.value.name
   description = each.value.name
 
@@ -85,6 +85,6 @@ resource "proxmox_vm_qemu" "nfs_nodes" {
 
   # Setup ip address using cloud-init
   # Keep in mind to use CIDR notation for the ip
-  ipconfig0 = "ip=${var.static_ip_prefix}.${local.nfs_node_start_id_suffix + tonumber(each.key)}/${var.network_prefix},gw=${var.network_gateway}"
-  vmid      = "3${local.nfs_node_start_id_suffix + tonumber(each.key)}"
+  ipconfig0 = "ip=${var.static_ip_prefix}.${local.nfs_node_start_id_suffix + each.value._idx}/${var.network_prefix},gw=${var.network_gateway}"
+  vmid      = "3${local.nfs_node_start_id_suffix + each.value._idx}"
 }

--- a/r_nfs_node.tf
+++ b/r_nfs_node.tf
@@ -1,90 +1,24 @@
-resource "proxmox_vm_qemu" "nfs_nodes" {
-  for_each    = { for idx, cp in var.nfs_nodes : cp.name => merge(cp, { _idx = idx }) }
+module "nfs_nodes" {
+  source   = "./modules/proxmox-vm"
+  for_each = { for idx, cp in var.nfs_nodes : cp.name => merge(cp, { _idx = idx }) }
+
   name        = each.value.name
-  description = each.value.name
-
-  # Node name has to be the same name as within the cluster
-  # this might not include the FQDN
   target_node = each.value.node
+  clone       = var.template
 
-  # The destination resource pool for the new VM
-  # pool = "pool0"
+  cores  = var.vm_resources["node_${each.value.type}"].cores
+  memory = var.vm_resources["node_${each.value.type}"].memory
 
-  # The template name to clone this vm from
-  clone = var.template
+  scsi0_size    = var.vm_resources["node_${each.value.type}"].disk
+  scsi0_storage = each.value.storage
 
-  # Activate QEMU agent for this VM
-  agent = 1
+  tags          = each.value.tags
+  startup_order = 1
 
-  os_type = "cloud-init"
-
-  cpu {
-    cores   = var.vm_resources["node_${each.value.type}"].cores
-    vcores  = 0
-    sockets = 1
-    type    = "host"
-  }
-
-  memory             = var.vm_resources["node_${each.value.type}"].memory
-  scsihw             = "virtio-scsi-pci"
-  bootdisk           = "scsi0"
-  start_at_node_boot = true
-  tags               = each.value.tags
-
-  startup_shutdown {
-    order         = 1
-    startup_delay = 10
-  }
-
-  lifecycle {
-    ignore_changes = [bootdisk]
-  }
-
-  # Setup the disk
-  disks {
-    ide {
-      ide2 {
-        cloudinit {
-          storage = "local-lvm"
-        }
-      }
-    }
-    scsi {
-      scsi0 {
-        disk {
-          size    = var.vm_resources["node_${each.value.type}"].disk
-          cache   = "none"
-          storage = each.value.storage
-          # discard    = true
-          # backup     = true
-          # asyncio    = "io_uring"
-        }
-      }
-    }
-  }
-
-
-  # Setup Network interface and assign vlan tag
-  network {
-    id     = 0
-    model  = "virtio"
-    bridge = "vmbr0"
-  }
-
-  boot = "order=scsi0"
-
-  # Cloud init Settings
   ciuser     = var.cloudinit_user
   cipassword = var.cloudinit_password
-  ciupgrade  = false
   sshkeys    = var.cloudinit_sshkey
 
-  # DNS Settings
-  # searchdomain = var.dns_domain
-  # nameserver   = var.dns_nameserver
-
-  # Setup ip address using cloud-init
-  # Keep in mind to use CIDR notation for the ip
   ipconfig0 = "ip=${var.static_ip_prefix}.${local.nfs_node_start_id_suffix + each.value._idx}/${var.network_prefix},gw=${var.network_gateway}"
   vmid      = "3${local.nfs_node_start_id_suffix + each.value._idx}"
 }

--- a/r_worker_nodes.tf
+++ b/r_worker_nodes.tf
@@ -1,6 +1,6 @@
 
 resource "proxmox_vm_qemu" "worker_nodes" {
-  for_each    = { for idx, cp in var.worker_nodes : idx => cp }
+  for_each    = { for idx, cp in var.worker_nodes : cp.name => cp }
   name        = each.value.name
   description = each.value.name
 

--- a/r_worker_nodes.tf
+++ b/r_worker_nodes.tf
@@ -1,100 +1,32 @@
 
-resource "proxmox_vm_qemu" "worker_nodes" {
-  for_each    = { for idx, cp in var.worker_nodes : cp.name => cp }
+module "worker_nodes" {
+  source   = "./modules/proxmox-vm"
+  for_each = { for idx, cp in var.worker_nodes : cp.name => cp }
+
   name        = each.value.name
-  description = each.value.name
-
-  # Node name has to be the same name as within the cluster
-  # this might not include the FQDN
   target_node = each.value.node
+  clone       = var.template
 
-  # The destination resource pool for the new VM
-  # pool = "pool0"
-
-  # The template name to clone this vm from
-  clone = var.template
-
-  # Activate QEMU agent for this VM
-  agent = 1
-
-  os_type = "cloud-init"
+  cores   = var.vm_resources["worker_${each.value.type}"].cores
   memory  = var.vm_resources["worker_${each.value.type}"].memory
   balloon = var.vm_resources["worker_${each.value.type}"].balloon
 
-  cpu {
-    cores   = var.vm_resources["worker_${each.value.type}"].cores
-    vcores  = 0
-    sockets = 1
-    type    = "host"
-  }
+  scsi0_size    = var.vm_resources["worker_${each.value.type}"].disk
+  scsi0_storage = "local-lvm"
 
-  scsihw             = "virtio-scsi-pci"
-  bootdisk           = "scsi0"
-  start_at_node_boot = true
-  tags               = var.tags["k8s_worker"]
+  scsi1_size    = var.vm_resources["worker_${each.value.type}"].longhorn_disk
+  scsi1_storage = each.value.longhorn_storage
 
-  startup_shutdown {
-    order         = 8
-    startup_delay = 10
-  }
+  tags          = var.tags["k8s_worker"]
+  startup_order = 8
 
-  lifecycle {
-    ignore_changes = [bootdisk]
-  }
-
-  # Setup the disk
-  disks {
-    ide {
-      ide2 {
-        cloudinit {
-          storage = "local-lvm"
-        }
-      }
-    }
-    scsi {
-      scsi0 {
-        disk {
-          size    = var.vm_resources["worker_${each.value.type}"].disk
-          cache   = "none"
-          storage = "local-lvm"
-        }
-      }
-
-      dynamic "scsi1" {
-        for_each = var.vm_resources["worker_${each.value.type}"].longhorn_disk != null ? [1] : []
-        content {
-          disk {
-            size    = var.vm_resources["worker_${each.value.type}"].longhorn_disk
-            cache   = "none"
-            storage = each.value.longhorn_storage
-          }
-        }
-      }
-    }
-  }
-
-
-  # Setup Network interface and assign vlan tag
-  network {
-    id     = 0
-    model  = "virtio"
-    bridge = "vmbr0"
-  }
-
-  boot = "order=scsi0"
-
-  # Cloud init Settings
   ciuser     = var.cloudinit_user
   cipassword = var.cloudinit_password
-  ciupgrade  = false
   sshkeys    = var.cloudinit_sshkey
 
-  # DNS Settings
   searchdomain = var.dns_domain
   nameserver   = var.dns_nameserver
 
-  # Setup ip address using cloud-init
-  # Keep in mind to use CIDR notation for the ip
   ipconfig0 = "ip=${var.static_ip_prefix}.${local.worker_suffixes[each.value.type] + tonumber(each.value.index)}/${var.network_prefix},gw=${var.network_gateway}"
   vmid      = "3${local.worker_suffixes[each.value.type] + tonumber(each.value.index)}"
 }

--- a/tmp/refactor-plan.md
+++ b/tmp/refactor-plan.md
@@ -1,0 +1,78 @@
+# Terraform Proxmox Refactor Plan (Single Environment)
+
+## Goals and Guardrails
+- Keep the current workflow: run `terraform plan` / `terraform apply` from repo root.
+- Reduce duplication across `r_*.tf` files.
+- Make later multi-environment support a directory move, not a rewrite.
+- Non-negotiable: no existing VM may be destroyed or recreated.
+- VMIDs and IPs are locked and must not change (Ansible depends on them).
+
+## Phase 0: Safety and Hygiene (no behavior changes)
+1) Expand `.gitignore` to avoid leaking state and plans:
+   - Add: `*.tfstate*`, `tfplan`, `crash.log`, `.env.*`
+2) Baseline checks:
+   - `terraform fmt`
+   - `terraform validate`
+   - `terraform plan -out=tfplan`
+3) Capture a “known good” plan summary before refactoring.
+4) Hard stop rule for all phases:
+   - If `terraform plan` shows any destroy/recreate for existing VMs, stop and fix before proceeding.
+
+## Phase 1: Normalize Inputs (prepare for modules)
+1) Introduce a unified `vm_profiles` map in `variables.tf`:
+   - Keys like `control_plane`, `worker.large`, `vm.micro`
+2) Stabilize resource addressing before modules:
+   - Convert `for_each = { for idx, n in var.* : idx => n }`
+   - To `for_each = { for n in var.* : n.name => n }`
+   - Use `moved` blocks so Terraform does not recreate VMs
+   - Pre-check: ensure all names are unique within each role list
+3) Add validation:
+   - `node` must be in `var.proxmox_nodes`
+   - profile keys referenced by nodes must exist
+4) Create locals that standardize naming and tags:
+   - e.g., `local.common_tags`, `local.name_prefix`
+
+## Phase 2: Create a Reusable VM Module
+Create `modules/proxmox-vm/` that wraps `proxmox_vm_qemu`.
+
+Suggested interface:
+- Inputs: `name`, `target_node`, `profile`, `storage`, `ip_config`, `tags`, `disks`, `clone`
+- Outputs: `vm_id`, `name`, `ipv4`
+
+Keep this module focused on VM creation only (no role logic).
+
+## Phase 3: Migrate One Role at a Time
+1) Migrate `control_planes` first:
+   - Replace the resource in `r_control_planes.tf` with a module call.
+   - Ensure VM IDs, names, and tags stay identical.
+2) Validate:
+   - `terraform fmt && terraform validate`
+   - `terraform plan -out=tfplan` (expect no or minimal drift)
+3) Repeat for `worker_nodes`, then `nfs_nodes`, then `hl_vm_nodes`.
+
+## Phase 4: Consolidate and Simplify
+- Remove duplicate per-role logic that is now inside the module.
+- Keep role-specific files, but have them only define data + module calls.
+
+## Gaps and Mitigations (found during plan review)
+1) **State/plan files are currently unignored**
+   - Gap: `.gitignore` only includes `.terraform/`, `terraform.tfvars`, `.env`
+   - Fix: add `*.tfstate*` and `tfplan` in Phase 0
+2) **Node validation would fail with current defaults**
+   - Gap: `var.proxmox_nodes` does not include nodes like `pve-n11`, `pve-n12`, `pve-l21`
+   - Fix: either expand `var.proxmox_nodes` or defer strict validation until it matches reality
+3) **Index-based `for_each` is fragile today**
+   - Gap: current resources key by index, so reordering lists can force recreation
+   - Fix: switch to name-keyed `for_each` early, with `moved` blocks
+4) **Resource migration can trigger unexpected recreation**
+   - Gap: moving from `resource` to `module` changes addresses again
+   - Fix: use `moved` blocks to map old addresses to new ones (second wave)
+5) **Provider quirks around disks/cloud-init**
+   - Gap: Telmate provider fields can be sensitive to block structure changes
+   - Fix: keep module blocks as close as possible to current resource arguments; migrate one role and plan carefully before proceeding
+
+## Validation Checklist per Step
+- `terraform fmt`
+- `terraform validate`
+- `terraform plan -out=tfplan`
+- Review for: any destroy/recreate (must be zero), disk changes, network changes, VM ID changes, IP changes

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,6 @@ variable "hl_vm_nodes" {
     { name = "docker-net", node = "pve-l21", type = "micro_docker", storage = "local-lvm", clone = true, tags = "docker;network;sensitive" },
     { name = "minio", node = "pve-main", type = "medium", storage = "local-lvm", extra_disk = "hdd_large", clone = true, tags = "storage;sensitive" },
     { name = "docker-priv", node = "pve-n12", type = "medium_docker", storage = "local-lvm", vm_id_suffix = 5, clone = true, tags = "admin;docker;sensitive" },
-    { name = "harness-delegate-1", node = "pve-n12", type = "medium_delegate", storage = "local-lvm", vm_id_suffix = 124, clone = true, tags = "automation;delegate;docker;harness;sensitive" },
+    { name = "harness-delegate-1", node = "pve-n13", type = "medium_delegate", storage = "local-lvm", vm_id_suffix = 124, clone = true, tags = "automation;delegate;docker;harness;sensitive" },
   ]
 }


### PR DESCRIPTION
# Terraform Proxmox Refactor Plan (Single Environment)

## Goals and Guardrails
- Keep the current workflow: run `terraform plan` / `terraform apply` from repo root.
- Reduce duplication across `r_*.tf` files.
- Make later multi-environment support a directory move, not a rewrite.
- Non-negotiable: no existing VM may be destroyed or recreated.
- VMIDs and IPs are locked and must not change (Ansible depends on them).

## Phase 0: Safety and Hygiene (no behavior changes)
1) Expand `.gitignore` to avoid leaking state and plans:
   - Add: `*.tfstate*`, `tfplan`, `crash.log`, `.env.*`
2) Baseline checks:
   - `terraform fmt`
   - `terraform validate`
   - `terraform plan -out=tfplan`
3) Capture a “known good” plan summary before refactoring.
4) Hard stop rule for all phases:
   - If `terraform plan` shows any destroy/recreate for existing VMs, stop and fix before proceeding.

## Phase 1: Normalize Inputs (prepare for modules)
1) Introduce a unified `vm_profiles` map in `variables.tf`:
   - Keys like `control_plane`, `worker.large`, `vm.micro`
2) Stabilize resource addressing before modules:
   - Convert `for_each = { for idx, n in var.* : idx => n }`
   - To `for_each = { for n in var.* : n.name => n }`
   - Use `moved` blocks so Terraform does not recreate VMs
   - Pre-check: ensure all names are unique within each role list
3) Add validation:
   - `node` must be in `var.proxmox_nodes`
   - profile keys referenced by nodes must exist
4) Create locals that standardize naming and tags:
   - e.g., `local.common_tags`, `local.name_prefix`

## Phase 2: Create a Reusable VM Module
Create `modules/proxmox-vm/` that wraps `proxmox_vm_qemu`.

Suggested interface:
- Inputs: `name`, `target_node`, `profile`, `storage`, `ip_config`, `tags`, `disks`, `clone`
- Outputs: `vm_id`, `name`, `ipv4`

Keep this module focused on VM creation only (no role logic).

## Phase 3: Migrate One Role at a Time
1) Migrate `control_planes` first:
   - Replace the resource in `r_control_planes.tf` with a module call.
   - Ensure VM IDs, names, and tags stay identical.
2) Validate:
   - `terraform fmt && terraform validate`
   - `terraform plan -out=tfplan` (expect no or minimal drift)
3) Repeat for `worker_nodes`, then `nfs_nodes`, then `hl_vm_nodes`.

## Phase 4: Consolidate and Simplify
- Remove duplicate per-role logic that is now inside the module.
- Keep role-specific files, but have them only define data + module calls.

## Gaps and Mitigations (found during plan review)
1) **State/plan files are currently unignored**
   - Gap: `.gitignore` only includes `.terraform/`, `terraform.tfvars`, `.env`
   - Fix: add `*.tfstate*` and `tfplan` in Phase 0
2) **Node validation would fail with current defaults**
   - Gap: `var.proxmox_nodes` does not include nodes like `pve-n11`, `pve-n12`, `pve-l21`
   - Fix: either expand `var.proxmox_nodes` or defer strict validation until it matches reality
3) **Index-based `for_each` is fragile today**
   - Gap: current resources key by index, so reordering lists can force recreation
   - Fix: switch to name-keyed `for_each` early, with `moved` blocks
4) **Resource migration can trigger unexpected recreation**
   - Gap: moving from `resource` to `module` changes addresses again
   - Fix: use `moved` blocks to map old addresses to new ones (second wave)
5) **Provider quirks around disks/cloud-init**
   - Gap: Telmate provider fields can be sensitive to block structure changes
   - Fix: keep module blocks as close as possible to current resource arguments; migrate one role and plan carefully before proceeding

## Validation Checklist per Step
- `terraform fmt`
- `terraform validate`
- `terraform plan -out=tfplan`
- Review for: any destroy/recreate (must be zero), disk changes, network changes, VM ID changes, IP changes
