### PR TITLE
chore: add validation and node allowlist safeguards

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,15 @@ variable "dns_nameserver" { type = string }
 variable "dns_domain" { type = string }
 
 variable "proxmox_nodes" {
-  default = ["pve-main", "pve-node-1"]
+  type = set(string)
+  default = [
+    "pve-main",
+    "pve-n11",
+    "pve-n12",
+    "pve-n13",
+    "pve-l21",
+    "pve-node-1",
+  ]
 }
 
 variable "vm_resources" {
@@ -70,6 +78,16 @@ variable "control_planes" {
   default = [
     { name = "k8s-ctrl-0", node = "pve-main" },
   ]
+
+  validation {
+    condition     = length(distinct([for n in var.control_planes : n.name])) == length(var.control_planes)
+    error_message = "control_planes names must be unique."
+  }
+
+  validation {
+    condition     = alltrue([for n in var.control_planes : contains(var.proxmox_nodes, n.node)])
+    error_message = "All control_planes.node values must be in var.proxmox_nodes."
+  }
 }
 
 variable "worker_nodes" {
@@ -88,6 +106,21 @@ variable "worker_nodes" {
     { name = "k8s-worker-3", node = "pve-n11", type = "large", index = 3, longhorn_storage = "local-lvm" },
     { name = "k8s-worker-sm-0", node = "pve-n11", type = "small", index = 0, longhorn_storage = "local-lvm" },
   ]
+
+  validation {
+    condition     = length(distinct([for n in var.worker_nodes : n.name])) == length(var.worker_nodes)
+    error_message = "worker_nodes names must be unique."
+  }
+
+  validation {
+    condition     = length(distinct([for n in var.worker_nodes : "${n.type}:${n.index}"])) == length(var.worker_nodes)
+    error_message = "worker_nodes must not reuse the same type+index (vmid/ip collision risk)."
+  }
+
+  validation {
+    condition     = alltrue([for n in var.worker_nodes : contains(var.proxmox_nodes, n.node)])
+    error_message = "All worker_nodes.node values must be in var.proxmox_nodes."
+  }
 }
 
 variable "nfs_nodes" {
@@ -102,6 +135,16 @@ variable "nfs_nodes" {
   default = [
     { name = "k8s-nfs-storage", node = "pve-n11", type = "small", storage = "local-lvm", tags = "k8s;network;storage;sensitive" },
   ]
+
+  validation {
+    condition     = length(distinct([for n in var.nfs_nodes : n.name])) == length(var.nfs_nodes)
+    error_message = "nfs_nodes names must be unique."
+  }
+
+  validation {
+    condition     = alltrue([for n in var.nfs_nodes : contains(var.proxmox_nodes, n.node)])
+    error_message = "All nfs_nodes.node values must be in var.proxmox_nodes."
+  }
 }
 
 variable "hl_vm_nodes" {
@@ -126,4 +169,23 @@ variable "hl_vm_nodes" {
     { name = "harness-delegate-1", node = "pve-n13", type = "medium_delegate", storage = "local-lvm", vm_id_suffix = 124, clone = true, tags = "automation;delegate;docker;harness;sensitive" },
     { name = "harness-delegate-2", node = "pve-n13", type = "medium_delegate", storage = "local-lvm", vm_id_suffix = 125, clone = true, tags = "automation;delegate;docker;harness;sensitive" },
   ]
+
+  validation {
+    condition     = length(distinct([for n in var.hl_vm_nodes : n.name])) == length(var.hl_vm_nodes)
+    error_message = "hl_vm_nodes names must be unique."
+  }
+
+  validation {
+    condition = length(distinct([
+      for n in var.hl_vm_nodes : n.vm_id_suffix if n.vm_id_suffix != null
+      ])) == length([
+      for n in var.hl_vm_nodes : n.vm_id_suffix if n.vm_id_suffix != null
+    ])
+    error_message = "hl_vm_nodes vm_id_suffix values must be unique when set."
+  }
+
+  validation {
+    condition     = alltrue([for n in var.hl_vm_nodes : contains(var.proxmox_nodes, n.node)])
+    error_message = "All hl_vm_nodes.node values must be in var.proxmox_nodes."
+  }
 }


### PR DESCRIPTION
Adds input validations and a Proxmox node allowlist. Verified with: terraform plan -out=tfplan (no changes).