### PR TITLE
refactor: model node definitions as maps keyed by name

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -13,3 +13,22 @@ locals {
     large = local.worker_large_start_id_suffix
   }
 }
+
+locals {
+  # Explicit VMID/IP suffix registry to break dependence on list ordering.
+  vmid_suffix_by_name = {
+    k8s-ctrl-0         = 150
+    k8s-worker-0       = 170
+    k8s-worker-1       = 171
+    k8s-worker-2       = 172
+    k8s-worker-3       = 173
+    k8s-worker-sm-0    = 180
+    k8s-nfs-storage    = 110
+    tailscale          = 120
+    docker-net         = 121
+    minio              = 122
+    docker-priv        = 5
+    harness-delegate-1 = 124
+    harness-delegate-2 = 125
+  }
+}

--- a/r_control_planes.tf
+++ b/r_control_planes.tf
@@ -22,6 +22,6 @@ module "control_planes" {
   searchdomain = var.dns_domain
   nameserver   = var.dns_nameserver
 
-  ipconfig0 = "ip=${var.static_ip_prefix}.${local.control_plane_start_id_suffix + each.value._idx}/${var.network_prefix},gw=${var.network_gateway}"
-  vmid      = "3${local.control_plane_start_id_suffix + each.value._idx}"
+  ipconfig0 = "ip=${var.static_ip_prefix}.${local.vmid_suffix_by_name[each.key]}/${var.network_prefix},gw=${var.network_gateway}"
+  vmid      = "3${local.vmid_suffix_by_name[each.key]}"
 }

--- a/r_control_planes.tf
+++ b/r_control_planes.tf
@@ -1,8 +1,8 @@
 module "control_planes" {
   source   = "./modules/proxmox-vm"
-  for_each = { for idx, cp in var.control_planes : cp.name => merge(cp, { _idx = idx }) }
+  for_each = var.control_planes
 
-  name        = each.value.name
+  name        = each.key
   target_node = each.value.node
   clone       = var.template
 

--- a/r_hl_vm_node.tf
+++ b/r_hl_vm_node.tf
@@ -23,12 +23,10 @@ module "hl_vm_nodes" {
   cipassword = var.cloudinit_password
   sshkeys    = var.cloudinit_sshkey
 
-  vmid = (each.value.vm_id_suffix != null ?
-    3000 + each.value.vm_id_suffix :
-    3000 + local.hl_vm_node_start_id_suffix + each.value._idx
+  vmid = 3000 + (
+    each.value.vm_id_suffix != null ? each.value.vm_id_suffix : local.vmid_suffix_by_name[each.key]
   )
   ipconfig0 = "ip=${var.static_ip_prefix}.${
-    each.value.vm_id_suffix != null ? each.value.vm_id_suffix :
-    local.hl_vm_node_start_id_suffix + each.value._idx
+    each.value.vm_id_suffix != null ? each.value.vm_id_suffix : local.vmid_suffix_by_name[each.key]
   }/${var.network_prefix},gw=${var.network_gateway}"
 }

--- a/r_hl_vm_node.tf
+++ b/r_hl_vm_node.tf
@@ -1,8 +1,8 @@
 module "hl_vm_nodes" {
   source   = "./modules/proxmox-vm"
-  for_each = { for idx, cp in var.hl_vm_nodes : cp.name => merge(cp, { _idx = idx }) }
+  for_each = var.hl_vm_nodes
 
-  name        = each.value.name
+  name        = each.key
   target_node = each.value.node
   clone       = try(each.value.clone, false) ? var.template : null
 

--- a/r_nfs_node.tf
+++ b/r_nfs_node.tf
@@ -1,8 +1,8 @@
 module "nfs_nodes" {
   source   = "./modules/proxmox-vm"
-  for_each = { for idx, cp in var.nfs_nodes : cp.name => merge(cp, { _idx = idx }) }
+  for_each = var.nfs_nodes
 
-  name        = each.value.name
+  name        = each.key
   target_node = each.value.node
   clone       = var.template
 

--- a/r_nfs_node.tf
+++ b/r_nfs_node.tf
@@ -19,6 +19,6 @@ module "nfs_nodes" {
   cipassword = var.cloudinit_password
   sshkeys    = var.cloudinit_sshkey
 
-  ipconfig0 = "ip=${var.static_ip_prefix}.${local.nfs_node_start_id_suffix + each.value._idx}/${var.network_prefix},gw=${var.network_gateway}"
-  vmid      = "3${local.nfs_node_start_id_suffix + each.value._idx}"
+  ipconfig0 = "ip=${var.static_ip_prefix}.${local.vmid_suffix_by_name[each.key]}/${var.network_prefix},gw=${var.network_gateway}"
+  vmid      = "3${local.vmid_suffix_by_name[each.key]}"
 }

--- a/r_worker_nodes.tf
+++ b/r_worker_nodes.tf
@@ -27,6 +27,6 @@ module "worker_nodes" {
   searchdomain = var.dns_domain
   nameserver   = var.dns_nameserver
 
-  ipconfig0 = "ip=${var.static_ip_prefix}.${local.worker_suffixes[each.value.type] + tonumber(each.value.index)}/${var.network_prefix},gw=${var.network_gateway}"
-  vmid      = "3${local.worker_suffixes[each.value.type] + tonumber(each.value.index)}"
+  ipconfig0 = "ip=${var.static_ip_prefix}.${local.vmid_suffix_by_name[each.key]}/${var.network_prefix},gw=${var.network_gateway}"
+  vmid      = "3${local.vmid_suffix_by_name[each.key]}"
 }

--- a/r_worker_nodes.tf
+++ b/r_worker_nodes.tf
@@ -1,9 +1,9 @@
 
 module "worker_nodes" {
   source   = "./modules/proxmox-vm"
-  for_each = { for idx, cp in var.worker_nodes : cp.name => cp }
+  for_each = var.worker_nodes
 
-  name        = each.value.name
+  name        = each.key
   target_node = each.value.node
   clone       = var.template
 

--- a/variables.tf
+++ b/variables.tf
@@ -70,86 +70,71 @@ variable "tags" {
 }
 
 variable "control_planes" {
-  type = list(object({
-    name = string
+  type = map(object({
     node = string
   }))
 
-  default = [
-    { name = "k8s-ctrl-0", node = "pve-main" },
-  ]
-
-  validation {
-    condition     = length(distinct([for n in var.control_planes : n.name])) == length(var.control_planes)
-    error_message = "control_planes names must be unique."
+  default = {
+    k8s-ctrl-0 = { node = "pve-main" }
   }
 
   validation {
-    condition     = alltrue([for n in var.control_planes : contains(var.proxmox_nodes, n.node)])
+    condition     = alltrue([for n in values(var.control_planes) : contains(var.proxmox_nodes, n.node)])
     error_message = "All control_planes.node values must be in var.proxmox_nodes."
   }
 }
 
 variable "worker_nodes" {
-  type = list(object({
-    name             = string
+  type = map(object({
     node             = string
     type             = string
     index            = number
     longhorn_storage = string
   }))
-  default = [
-    { name = "k8s-worker-0", node = "pve-main", type = "large", index = 0, longhorn_storage = "thinpool-ssd" },
-    { name = "k8s-worker-1", node = "pve-main", type = "large", index = 1, longhorn_storage = "thinpool-ssd" },
-    { name = "k8s-worker-2", node = "pve-main", type = "large", index = 2, longhorn_storage = "thinpool-ssd" },
-
-    { name = "k8s-worker-3", node = "pve-n11", type = "large", index = 3, longhorn_storage = "local-lvm" },
-    { name = "k8s-worker-sm-0", node = "pve-n11", type = "small", index = 0, longhorn_storage = "local-lvm" },
-  ]
-
-  validation {
-    condition     = length(distinct([for n in var.worker_nodes : n.name])) == length(var.worker_nodes)
-    error_message = "worker_nodes names must be unique."
+  default = {
+    k8s-worker-0    = { node = "pve-main", type = "large", index = 0, longhorn_storage = "thinpool-ssd" }
+    k8s-worker-1    = { node = "pve-main", type = "large", index = 1, longhorn_storage = "thinpool-ssd" }
+    k8s-worker-2    = { node = "pve-main", type = "large", index = 2, longhorn_storage = "thinpool-ssd" }
+    k8s-worker-3    = { node = "pve-n11", type = "large", index = 3, longhorn_storage = "local-lvm" }
+    k8s-worker-sm-0 = { node = "pve-n11", type = "small", index = 0, longhorn_storage = "local-lvm" }
   }
 
   validation {
-    condition     = length(distinct([for n in var.worker_nodes : "${n.type}:${n.index}"])) == length(var.worker_nodes)
+    condition     = length(distinct([for n in values(var.worker_nodes) : "${n.type}:${n.index}"])) == length(var.worker_nodes)
     error_message = "worker_nodes must not reuse the same type+index (vmid/ip collision risk)."
   }
 
   validation {
-    condition     = alltrue([for n in var.worker_nodes : contains(var.proxmox_nodes, n.node)])
+    condition     = alltrue([for n in values(var.worker_nodes) : contains(var.proxmox_nodes, n.node)])
     error_message = "All worker_nodes.node values must be in var.proxmox_nodes."
   }
 }
 
 variable "nfs_nodes" {
-  type = list(object({
-    name    = string
+  type = map(object({
     node    = string
     type    = string
     storage = string
     tags    = optional(string)
   }))
 
-  default = [
-    { name = "k8s-nfs-storage", node = "pve-n11", type = "small", storage = "local-lvm", tags = "k8s;network;storage;sensitive" },
-  ]
-
-  validation {
-    condition     = length(distinct([for n in var.nfs_nodes : n.name])) == length(var.nfs_nodes)
-    error_message = "nfs_nodes names must be unique."
+  default = {
+    k8s-nfs-storage = {
+      node    = "pve-n11"
+      type    = "small"
+      storage = "local-lvm"
+      tags    = "k8s;network;storage;sensitive"
+    }
   }
 
   validation {
-    condition     = alltrue([for n in var.nfs_nodes : contains(var.proxmox_nodes, n.node)])
+    condition     = alltrue([for n in values(var.nfs_nodes) : contains(var.proxmox_nodes, n.node)])
     error_message = "All nfs_nodes.node values must be in var.proxmox_nodes."
   }
 }
 
 variable "hl_vm_nodes" {
-  type = list(object({
-    name    = string
+  type = map(object({
     node    = string
     type    = string
     storage = string
@@ -161,31 +146,26 @@ variable "hl_vm_nodes" {
     tags         = optional(string)
   }))
 
-  default = [
-    { name = "tailscale", node = "pve-l21", type = "micro", storage = "local-lvm", clone = true, tags = "network;sensitive;tailscale" },
-    { name = "docker-net", node = "pve-l21", type = "micro_docker", storage = "local-lvm", clone = true, tags = "docker;network;sensitive" },
-    { name = "minio", node = "pve-main", type = "medium", storage = "local-lvm", extra_disk = "hdd_large", clone = true, tags = "storage;sensitive" },
-    { name = "docker-priv", node = "pve-n12", type = "medium_docker", storage = "local-lvm", vm_id_suffix = 5, clone = true, tags = "admin;docker;sensitive" },
-    { name = "harness-delegate-1", node = "pve-n13", type = "medium_delegate", storage = "local-lvm", vm_id_suffix = 124, clone = true, tags = "automation;delegate;docker;harness;sensitive" },
-    { name = "harness-delegate-2", node = "pve-n13", type = "medium_delegate", storage = "local-lvm", vm_id_suffix = 125, clone = true, tags = "automation;delegate;docker;harness;sensitive" },
-  ]
-
-  validation {
-    condition     = length(distinct([for n in var.hl_vm_nodes : n.name])) == length(var.hl_vm_nodes)
-    error_message = "hl_vm_nodes names must be unique."
+  default = {
+    tailscale          = { node = "pve-l21", type = "micro", storage = "local-lvm", clone = true, tags = "network;sensitive;tailscale" }
+    docker-net         = { node = "pve-l21", type = "micro_docker", storage = "local-lvm", clone = true, tags = "docker;network;sensitive" }
+    minio              = { node = "pve-main", type = "medium", storage = "local-lvm", extra_disk = "hdd_large", clone = true, tags = "storage;sensitive" }
+    docker-priv        = { node = "pve-n12", type = "medium_docker", storage = "local-lvm", vm_id_suffix = 5, clone = true, tags = "admin;docker;sensitive" }
+    harness-delegate-1 = { node = "pve-n13", type = "medium_delegate", storage = "local-lvm", vm_id_suffix = 124, clone = true, tags = "automation;delegate;docker;harness;sensitive" }
+    harness-delegate-2 = { node = "pve-n13", type = "medium_delegate", storage = "local-lvm", vm_id_suffix = 125, clone = true, tags = "automation;delegate;docker;harness;sensitive" }
   }
 
   validation {
     condition = length(distinct([
-      for n in var.hl_vm_nodes : n.vm_id_suffix if n.vm_id_suffix != null
+      for n in values(var.hl_vm_nodes) : n.vm_id_suffix if n.vm_id_suffix != null
       ])) == length([
-      for n in var.hl_vm_nodes : n.vm_id_suffix if n.vm_id_suffix != null
+      for n in values(var.hl_vm_nodes) : n.vm_id_suffix if n.vm_id_suffix != null
     ])
     error_message = "hl_vm_nodes vm_id_suffix values must be unique when set."
   }
 
   validation {
-    condition     = alltrue([for n in var.hl_vm_nodes : contains(var.proxmox_nodes, n.node)])
+    condition     = alltrue([for n in values(var.hl_vm_nodes) : contains(var.proxmox_nodes, n.node)])
     error_message = "All hl_vm_nodes.node values must be in var.proxmox_nodes."
   }
 }


### PR DESCRIPTION
Locks VMID/IP by name, then migrates node inputs from lists to maps keyed by name. Verified with: terraform plan -out=tfplan
  (no changes).