### PR TITLE
chore: move minio storage profile to storage-main

### DIFF
--- a/environments/homelab/variables.tf
+++ b/environments/homelab/variables.tf
@@ -54,7 +54,7 @@ variable "vm_resources" {
     vm_medium_docker   = { cores = 2, memory = 6144, balloon = 4096, disk = 36 }
     vm_medium_delegate = { cores = 4, memory = 8192, balloon = 6144, disk = 36 }
 
-    storage_hdd_large = { size = 1024, source = "storage-hdd" }
+    storage_hdd_large = { size = 512, source = "storage-main" }
   }
 }
 

--- a/environments/test/variables.tf
+++ b/environments/test/variables.tf
@@ -54,7 +54,7 @@ variable "vm_resources" {
     vm_medium_docker   = { cores = 2, memory = 6144, balloon = 4096, disk = 36 }
     vm_medium_delegate = { cores = 4, memory = 8192, balloon = 6144, disk = 36 }
 
-    storage_hdd_large = { size = 1024, source = "storage-hdd" }
+    storage_hdd_large = { size = 512, source = "storage-main" }
   }
 }
 


### PR DESCRIPTION
## Summary
- move the MinIO extra disk storage profile from storage-hdd to storage-main
- reduce the MinIO extra disk profile size from 1024GB to 512GB
- keep homelab and test environment defaults aligned

## Validation
- terraform validate in environments/homelab
- terraform plan reviewed manually for MinIO disk drift
